### PR TITLE
NP-2405 Modify ingress for app-cluster-api

### DIFF
--- a/internal/pkg/workflow/commands/sync/k8s/ingress/entities.go
+++ b/internal/pkg/workflow/commands/sync/k8s/ingress/entities.go
@@ -577,6 +577,8 @@ var DeviceAPIIngressRules = v1beta1.Ingress{
 	},
 }
 
+// AppClusterAPIIngressRules redirects incoming traffic to the app-cluster-api. The service checks the client
+// certificate so it is required to pass the certificate information to the upstream service.
 var AppClusterAPIIngressRules = v1beta1.Ingress{
 	TypeMeta: metaV1.TypeMeta{
 		Kind:       "Ingress",
@@ -590,12 +592,14 @@ var AppClusterAPIIngressRules = v1beta1.Ingress{
 			"component": "ingress-nginx",
 		},
 		Annotations: map[string]string{
-			"kubernetes.io/ingress.class":                        "nginx",
-			"nginx.ingress.kubernetes.io/ssl-redirect":           "true",
-			"nginx.ingress.kubernetes.io/backend-protocol":       "GRPC",
-			"nginx.ingress.kubernetes.io/auth-tls-verify-client": "on",
-			"nginx.ingress.kubernetes.io/auth-tls-secret":        "nalej/ca-certificate",
-			"nginx.ingress.kubernetes.io/auth-tls-verify-depth":  "1",
+			"kubernetes.io/ingress.class":                                       "nginx",
+			"nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream": "true",
+			"nginx.ingress.kubernetes.io/ssl-redirect":                          "true",
+			"nginx.ingress.kubernetes.io/grpc-backend":                          "true",
+			"nginx.ingress.kubernetes.io/backend-protocol":                      "GRPC",
+			"nginx.ingress.kubernetes.io/auth-tls-verify-client":                "on",
+			"nginx.ingress.kubernetes.io/auth-tls-secret":                       "nalej/ca-certificate",
+			"nginx.ingress.kubernetes.io/auth-tls-verify-depth":                 "1",
 		},
 	},
 	Spec: v1beta1.IngressSpec{


### PR DESCRIPTION
#### What does this PR do?

* Modify the ingress of the `app-cluster-api` to include the new options required to check the identify of the management cluster.

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

Required options:

```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    kubernetes.io/ingress.class: nginx
    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
metadata:
    nginx.ingress.kubernetes.io/auth-tls-secret: nalej/ca-certificate
    nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "1"
    nginx.ingress.kubernetes.io/backend-protocol: GRPC
    nginx.ingress.kubernetes.io/grpc-backend: "true"
    nginx.ingress.kubernetes.io/ssl-redirect: "true"
```

#### What are the relevant tickets?

- [NP-2405](https://nalej.atlassian.net/browse/NP-2405)

#### Screenshots (if appropriate)

#### Questions
