### PR TITLE
NP-2483 new path 'log-download-manager' added to ingress-nginx

### DIFF
--- a/internal/pkg/workflow/commands/sync/k8s/ingress/entities.go
+++ b/internal/pkg/workflow/commands/sync/k8s/ingress/entities.go
@@ -223,6 +223,13 @@ var IngressRulesPaths = &v1beta1.HTTPIngressRuleValue{
 				ServicePort: intstr.IntOrString{IntVal: 8082},
 			},
 		},
+		v1beta1.HTTPIngressPath{
+			Path: "/v1/logs/download",
+			Backend: v1beta1.IngressBackend{
+				ServiceName: "log-download-manager",
+				ServicePort: intstr.IntOrString{IntVal: 8941},
+			},
+		},
 	},
 }
 


### PR DESCRIPTION
#### What does this PR do?
new path `log-download-manager` added in the ingress `ingress-nginx`
#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2483](https://nalej.atlassian.net/browse/NP-2483)

#### Screenshots (if appropriate)

#### Questions
