### PR TITLE
Feature/np 453 yaml platform overwrite

### DIFF
--- a/internal/pkg/workflow/commands/sync/k8s/launch.go
+++ b/internal/pkg/workflow/commands/sync/k8s/launch.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/nalej/derrors"
@@ -97,40 +98,64 @@ func (lc *LaunchComponents) Run(workflowID string) (*entities.CommandResult, der
 			return nil, createErr
 		}
 	}
-
-	fileInfo, err := ioutil.ReadDir(lc.ComponentsDir)
+	// Get the preprocessed list of components to be installed on the target Kubernetes.
+	components, err := lc.ListComponents()
 	if err != nil {
-		return nil, derrors.AsError(err, "cannot read components dir")
+		return nil, err
 	}
+
 	numLaunched := 0
-	for _, file := range fileInfo {
-		if strings.HasSuffix(file.Name(), ".yaml") {
-			log.Info().Str("file", file.Name()).Msg("processing component")
-			err := lc.launchComponent(path.Join(lc.ComponentsDir, file.Name()), targetEnvironment)
-			if err != nil {
-				return entities.NewCommandResult(false, "cannot launch component", err), nil
-			}
-			numLaunched++
+	for _, fileName := range components {
+		log.Info().Str("fileName", fileName).Msg("processing component")
+		err := lc.launchComponent(path.Join(lc.ComponentsDir, fileName), targetEnvironment)
+		if err != nil {
+			return entities.NewCommandResult(false, "cannot launch component", err), nil
 		}
+		numLaunched++
 	}
 	msg := fmt.Sprintf("%d components have been launched", numLaunched)
 	return entities.NewCommandResult(true, msg, nil), nil
 }
 
-// ListComponents obtains a list of the files that need to be installed.
-// TODO Overwrite files if a *.yaml.minikube file is found on the same entity with a MINIKUBE environment.
-func (lc *LaunchComponents) ListComponents() []string {
+// ListComponents obtains a list of the files that need to be installed. Platform dependent YAML files overwrite the
+// use of the common YAML. For example, if the install is for an Azure cluster, and there are a component.yaml and
+// component.yaml.azure files, the later will be used.
+func (lc *LaunchComponents) ListComponents() ([]string, derrors.Error) {
 	fileInfo, err := ioutil.ReadDir(lc.ComponentsDir)
 	if err != nil {
-		log.Fatal().Err(err).Str("componentsDir", lc.ComponentsDir).Msg("cannot read components dir")
+		log.Warn().Err(err).Str("componentsDir", lc.ComponentsDir).Msg("cannot read components dir")
+		return nil, derrors.NewInternalError("cannot read component directory", err)
 	}
-	result := make([]string, 0)
+	filesToCreate := make(map[string]bool, 0)
+	platformName := strings.ToLower(lc.PlatformType)
+	platformSuffix := fmt.Sprintf(".yaml.%s", platformName)
 	for _, file := range fileInfo {
-		if strings.HasSuffix(file.Name(), ".yaml") {
-			result = append(result, file.Name())
+		log.Info().Str("fileName", file.Name()).Str("platformSuffix", platformSuffix).Msg("Checking file")
+		if strings.HasSuffix(file.Name(), platformSuffix) {
+			log.Info().Msg("file has platform suffix, addint to list")
+			// A platform specific file is found, delete the common one if exists
+			platformIndependentName := strings.TrimSuffix(file.Name(), fmt.Sprintf(".%s", platformName))
+			delete(filesToCreate, platformIndependentName)
+			// Add the platform specific file to the list.
+			filesToCreate[file.Name()] = true
+		} else if strings.HasSuffix(file.Name(), ".yaml") {
+			log.Info().Msg("file is platform independent")
+			// Check if the platform specific equivalent is found
+			_, exists := filesToCreate[fmt.Sprintf("%s.%s", file.Name(), platformName)]
+			if !exists {
+				log.Info().Msg("adding file to list")
+				filesToCreate[file.Name()] = true
+			}
 		}
 	}
-	return result
+
+	result := make([]string, 0)
+	for toAdd, _ := range filesToCreate {
+		result = append(result, toAdd)
+	}
+	// Make sure to main the same order as in the listing of the original files.
+	sort.Strings(result)
+	return result, nil
 }
 
 // launchComponent triggers the creation of a given component from a YAML file
@@ -222,8 +247,14 @@ func (lc *LaunchComponents) PrettyPrint(indentation int) string {
 	simpleIden := strings.Repeat(" ", indentation) + "  "
 	entrySep := simpleIden + "  "
 	cStr := ""
-	for _, c := range lc.ListComponents() {
-		cStr = cStr + "\n" + entrySep + c
+	components, err := lc.ListComponents()
+	if err != nil {
+		log.Warn().Err(err).Msg("cannot list components")
+		cStr = cStr + "\n" + entrySep + "<unknown>"
+	} else {
+		for _, c := range components {
+			cStr = cStr + "\n" + entrySep + c
+		}
 	}
 	return strings.Repeat(" ", indentation) + lc.String() + cStr
 }

--- a/internal/pkg/workflow/commands/sync/k8s/launch_test.go
+++ b/internal/pkg/workflow/commands/sync/k8s/launch_test.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Nalej
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package k8s
+
+import (
+	"fmt"
+	"github.com/nalej/grpc-installer-go"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CreateTempYAML creates a directory with a set of yaml files.
+func CreateTempYAML(numYAML int, numPlatformYAML int, platforms ...string) string {
+	dir, err := ioutil.TempDir("", "launch")
+	gomega.Expect(err).Should(gomega.Succeed())
+	testData := []byte("test")
+	for i := 0; i < numYAML; i++ {
+		fileName := fmt.Sprintf("%d.yaml", i)
+		err := ioutil.WriteFile(filepath.Join(dir, fileName), testData, 0777)
+		gomega.Expect(err).Should(gomega.Succeed())
+	}
+
+	for _, targetPlatform := range platforms {
+		for i := 0; i < numPlatformYAML; i++ {
+			fileName := fmt.Sprintf("%d.yaml.%s", i, strings.ToLower(targetPlatform))
+			err := ioutil.WriteFile(filepath.Join(dir, fileName), testData, 0777)
+			gomega.Expect(err).Should(gomega.Succeed())
+		}
+	}
+
+	return dir
+}
+
+var _ = ginkgo.Describe("A Launch command", func() {
+	ginkgo.It("should list components if no platform-dependent are present", func() {
+		numYAML := 10
+		componentsDir := CreateTempYAML(numYAML, 0)
+		launchCmd := NewLaunchComponents("kubeConfigPath", []string{}, componentsDir, grpc_installer_go.Platform_AZURE.String())
+		toInstall, err := launchCmd.ListComponents()
+		gomega.Expect(err).To(gomega.Succeed())
+		gomega.Expect(toInstall).ShouldNot(gomega.BeNil())
+		gomega.Expect(len(toInstall)).Should(gomega.Equal(numYAML))
+		gomega.Expect(os.RemoveAll(componentsDir)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("should list components considering a single conflicting platform", func() {
+		numYAML := 10
+		componentsDir := CreateTempYAML(numYAML, numYAML, grpc_installer_go.Platform_AZURE.String())
+		launchCmd := NewLaunchComponents("kubeConfigPath", []string{}, componentsDir, grpc_installer_go.Platform_AZURE.String())
+		toInstall, err := launchCmd.ListComponents()
+		gomega.Expect(err).To(gomega.Succeed())
+		gomega.Expect(toInstall).ShouldNot(gomega.BeNil())
+		gomega.Expect(len(toInstall)).Should(gomega.Equal(numYAML))
+		gomega.Expect(os.RemoveAll(componentsDir)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("should list components considering a multiple conflicting platforms", func() {
+		numYAML := 10
+		numPlatformYAML := numYAML / 2
+		componentsDir := CreateTempYAML(numYAML, numPlatformYAML, grpc_installer_go.Platform_AZURE.String(), grpc_installer_go.Platform_BAREMETAL.String())
+		launchCmd := NewLaunchComponents("kubeConfigPath", []string{}, componentsDir, grpc_installer_go.Platform_AZURE.String())
+		toInstall, err := launchCmd.ListComponents()
+		gomega.Expect(err).To(gomega.Succeed())
+		gomega.Expect(toInstall).ShouldNot(gomega.BeNil())
+		gomega.Expect(len(toInstall)).Should(gomega.Equal(numYAML))
+		gomega.Expect(os.RemoveAll(componentsDir)).To(gomega.Succeed())
+		for i := 0; i < numYAML; i++ {
+			expectedName := fmt.Sprintf("%d.yaml.%s", i, strings.ToLower(launchCmd.PlatformType))
+			if i >= numPlatformYAML {
+				expectedName = fmt.Sprintf("%d.yaml", i)
+			}
+			gomega.Expect(toInstall[i]).Should(gomega.Equal(expectedName))
+		}
+	})
+})


### PR DESCRIPTION
#### What does this PR do?

* Add support for platform dependent YAML files

#### Where should the reviewer start?

* Changes in how the list of components to be installed is retrieved on the `launch` sync command.

#### What is missing?

* Unit tests are provided, but no manual install has been performed.

#### How should this be manually tested?

* Perform an install of the platform with such components.

#### Any background context you want to provide?

* The idea is that the user is able to provide platform specific YAML files to avoid the need of changing the installer for patching purposes. In this way the user will be able to provide a `mycomponent.yaml.<platform>` file that will be used instead of `mycomponent.yaml` in case the target platform matches `<platform>`

#### What are the relevant tickets?

- [NP-453](https://nalej.atlassian.net/browse/NP-453)

#### Screenshots (if appropriate)

#### Questions
